### PR TITLE
Add pytest suite for Ball collision logic and fix three-brick collision bug

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,61 @@
+# Contribution
+
+## What I Contributed
+
+I added a comprehensive pytest-based test suite for the `Ball` module, focusing on collision and movement behavior. The test suite covers:
+
+- Strike angle validation based on mouse drag direction and angle
+- Ball velocity changes when colliding with the top and side walls
+- Ball–brick collision handling for one, two, and three simultaneous brick collisions
+
+While writing these tests, I identified a `if / if / else` logic bug in three-brick collision handling. When three bricks are hit at once, the code correctly invokes the three-brick handler, but then also incorrectly calls the one-brick handler. This causes unintended extra velocity changes.  
+
+This issue is documented and exposed by the tests on the `master` branch and fixed on the `pytest` feature branch by restructuring the conditional logic to use an `if / elif / else` pattern.
+
+These tests add value by validating the most complex and error-prone logic in the game and by addressing a defect in the code itself.
+
+---
+
+## Process
+
+I began by reading through the existing `Ball` class to understand how movement, collisions, and angle calculations were implemented. I then designed tests around observable behaviors rather than internal implementation details.
+
+I used pytest’s parameterization features to cover multiple scenarios efficiently, especially for the collision cases where behavior changes based on geometry or direction. For brick collisions, I created lightweight fake brick objects with only the required `rect` attribute so that collision logic could be tested.
+
+After all tests were written and passing on the `master` branch (except for the known three-brick case), I created a `pytest` feature branch. On that branch, I applied a small fix to the collision handler logic and verified that the full test suite passed.
+
+Tools used:
+- Python
+- pytest
+- pygame (for Rect and collision geometry)
+- Git and GitHub
+
+---
+
+## Challenges
+
+The most significant challenge was understanding the brick collision logic, particularly how different numbers of simultaneous brick hits were handled. The code relies on geometric properties of rectangles and branching logic that is not immediately obvious.
+
+Another challenge was that the one-brick collision handler assumes `ball.rect` exists, while the three-brick handler does not. This inconsistency caused an AttributeError during testing, which ultimately helped reveal the underlying `if / if / else` logic error. I addressed this by setting up the test state and by documenting the issue clearly in both the tests and this contribution.
+
+---
+
+## Learning
+
+This contribution helped me better understand how to approach testing an existing codebase rather than code I wrote myself. In particular, I learned how important it is to test behavior at boundaries and edge cases, since that is often where bugs appear.
+
+I also gained experience using feature branches. While my initial development occurred on the fork’s default branch, I moved the bug fix and final documentation to a dedicated `pytest` feature branch to better align with standard Git workflow practices (and assignment instructions).
+
+Finally, I got some firsthand experience on how automated testing can reveal logic errors that can otherwise go unnoticed. In normal play, the `if / if / else` logic error would go unnoticed as draw would be constantly reassigning the required attribute that the testing environment did not create. 
+
+---
+
+## Future Work
+
+There are several areas that could be improved further:
+
+- Adding documentation or docstrings explaining the collision-handling rules more explicitly
+- Altering the game controls such that the direction of travel of the ball aligns with the mouse controls rather than the opposite behavior (push towards instead of pull away)
+- Expanding the testing suite to assess brick generation, countdown, and deletion
+
+These improvements were intentionally left out of this contribution to keep the scope focused on unit testing and collision behavior.

--- a/bbreaker/Ball.py
+++ b/bbreaker/Ball.py
@@ -118,7 +118,7 @@ class Ball(pygame.sprite.Sprite):
     def handle_brick_collisions(self, bricks_hit):
         if len(bricks_hit) == 3:
             self.handle_three_brick_collision()
-        if len(bricks_hit) == 2:
+        elif len(bricks_hit) == 2:
             self.handle_two_brick_collision(bricks_hit)
         else:
             self.handle_one_brick_collision(bricks_hit[0])

--- a/tests/test_ball.py
+++ b/tests/test_ball.py
@@ -194,14 +194,7 @@ def test_two_brick_collision_variants(vx, vy, case, expect_vx_positive, expect_v
 )
 
 def test_three_brick_collision_flips_both_axes(vx, vy, expect_vx_positive, expect_vy_positive):
-    # These tests failing reflects the structure for three-brick collision handling in Ball.py is misconstructed.
-    # As written, the method handler utilizes two if statements, not an if-elif-else structure,
-    # so that when three bricks are hit, the single-brick handler is also invoked after the three-brick handler,
-    # given a three-brick block collision. The logic of the handlers is such that the single-brick handler
-    # requires ball.rect to be set, whereas the handler does not require that parameter. In normal play,
-    # that isn't an issue, but in the testing suite it causes an AttributeError.
-    # To fix this issue, ball.handle_brick_collisions should be restructured to use if-elif-else.
-
+    
     pygame.display.set_mode((800, 600))
     surface = pygame.display.get_surface()
 

--- a/tests/test_ball.py
+++ b/tests/test_ball.py
@@ -57,3 +57,34 @@ def test_ball_bounces_off_top_wall(x, y, vx, vy, expect_vy_positive):
         assert ball.vy > 0
     else:
         assert ball.vy < 0
+
+# Arrange
+@pytest.mark.parametrize(
+    "x, y, vx, vy, expect_vx_positive",
+    [                           
+        (400, 200, -5, -5, False), # No wall contact - vx unchanged
+        (4, 200, -5, -5, True), # Left wall contact - vx flips
+        (796, 200, 5, -5, False), # Right wall contact - vx flips
+    ]
+)
+
+def test_ball_bounces_off_side_wall(x, y, vx, vy, expect_vx_positive):
+    # Arrange
+    pygame.display.set_mode((800, 600))
+    surface = pygame.display.get_surface()
+
+    ball = Ball(surface)
+    ball.x = x
+    ball.y = y
+    ball.vx = vx
+    ball.vy = vy
+    ball.game_on = True
+
+    # Act
+    ball.update(surface)
+
+    # Assert
+    if expect_vx_positive:
+        assert ball.vx > 0
+    else:
+        assert ball.vx < 0

--- a/tests/test_ball.py
+++ b/tests/test_ball.py
@@ -88,3 +88,142 @@ def test_ball_bounces_off_side_wall(x, y, vx, vy, expect_vx_positive):
         assert ball.vx > 0
     else:
         assert ball.vx < 0
+
+# Helper classes and functions for brick collision tests
+class FakeBrick:
+    def __init__(self, rect):
+        self.rect = rect
+
+def brick_at_point(point):
+    return FakeBrick(pygame.Rect(point[0], point[1], 1, 1)) # Make a 1x1 rect at the point
+
+# One-brick collision cases
+# Arrange
+@pytest.mark.parametrize(
+    "rect_origin, vx, vy, hit_point, expect_vx_positive, expect_vy_positive",
+    [
+        ((100, 100, 10, 10), 5, 5, "midright", False, True),   # midright - vx flips
+        ((120, 120, 10, 10), 5, 5, "midbottom", True, False),  # midbottom - vy flips
+        ((140, 140, 10, 10), 5, -5, "midtop", True, True),     # midtop - vy flips
+        ((160, 160, 10, 10), -5, -5, "midleft", True, False),  # midleft - vx flips
+    ],
+)
+def test_one_brick_collisions(rect_origin, vx, vy, hit_point, expect_vx_positive, expect_vy_positive):
+    pygame.display.set_mode((800, 600))
+    surface = pygame.display.get_surface()
+
+    ball = Ball(surface)
+    ball.rect = pygame.Rect(*rect_origin)
+    ball.vx, ball.vy = vx, vy
+
+    pt = getattr(ball.rect, hit_point)
+    bricks = [brick_at_point(pt)]
+
+    # Act
+    ball.handle_brick_collisions(bricks)
+
+    # Assert
+    if expect_vx_positive:
+        assert ball.vx > 0
+    else:
+        assert ball.vx < 0
+
+    if expect_vy_positive:
+        assert ball.vy > 0
+    else:
+        assert ball.vy < 0
+
+
+# Two-brick collision variant
+# Arrange
+@pytest.mark.parametrize(
+    "vx, vy, case, expect_vx_positive, expect_vy_positive",
+    [
+        (5, -5, "same_center_x", False, False),   # vx flips
+        (-5, -5, "same_center_x", True, False),   # vx flips
+        (5, -5, "same_center_y", True, True),     # vy flips
+        (5, 5, "same_center_y", True, False),     # vy flips
+        (5, 5, "different_centers", False, False),   # Both axes flip
+        (-5, -5, "different_centers", True, True),   # Both axes flip
+    ],
+)
+
+def test_two_brick_collision_variants(vx, vy, case, expect_vx_positive, expect_vy_positive):
+    pygame.display.set_mode((800, 600))
+    surface = pygame.display.get_surface()
+
+    ball = Ball(surface)
+    ball.vx, ball.vy = vx, vy
+
+    if case == "same_center_x":
+        b1 = FakeBrick(pygame.Rect(90, 90, 20, 20))
+        b2 = FakeBrick(pygame.Rect(90, 200, 20, 20))
+    elif case == "same_center_y":
+        b1 = FakeBrick(pygame.Rect(90, 90, 20, 20))
+        b2 = FakeBrick(pygame.Rect(200, 90, 20, 20))
+    else:
+        b1 = FakeBrick(pygame.Rect(10, 10, 20, 20))
+        b2 = FakeBrick(pygame.Rect(200, 200, 20, 20))
+
+    # Act
+    ball.handle_brick_collisions([b1, b2])
+
+    # Assert
+    if expect_vx_positive:
+        assert ball.vx > 0
+    else:
+        assert ball.vx < 0
+
+    if expect_vy_positive:
+        assert ball.vy > 0
+    else:
+        assert ball.vy < 0
+
+
+# Three-brick collision case
+# Arrange
+@pytest.mark.parametrize(
+    "vx, vy, expect_vx_positive, expect_vy_positive",
+    [
+        # In all situations of 3-brick collisions, all velocity components should flip
+        (-5, 5, True, False),    # Left and down - both axes flip
+        (5, -5, False, True),    # Right and up - both axes flip
+        (5, 5, False, False),    # Right and down – both axes flip
+        (-5, -5, True, True),    # Left and up – both axes flip
+    ],
+)
+
+def test_three_brick_collision_flips_both_axes(vx, vy, expect_vx_positive, expect_vy_positive):
+    # These tests failing reflects the structure for three-brick collision handling in Ball.py is misconstructed.
+    # As written, the method handler utilizes two if statements, not an if-elif-else structure,
+    # so that when three bricks are hit, the single-brick handler is also invoked after the three-brick handler,
+    # given a three-brick block collision. The logic of the handlers is such that the single-brick handler
+    # requires ball.rect to be set, whereas the handler does not require that parameter. In normal play,
+    # that isn't an issue, but in the testing suite it causes an AttributeError.
+    # To fix this issue, ball.handle_brick_collisions should be restructured to use if-elif-else.
+
+    pygame.display.set_mode((800, 600))
+    surface = pygame.display.get_surface()
+
+    ball = Ball(surface)
+    ball.vx, ball.vy = vx, vy
+
+    bricks = [
+        FakeBrick(pygame.Rect(10, 10, 20, 20)),
+        FakeBrick(pygame.Rect(50, 50, 20, 20)),
+        FakeBrick(pygame.Rect(90, 90, 20, 20)),
+    ]
+
+    # Act
+    ball.handle_brick_collisions(bricks)
+
+    # Assert
+    if expect_vx_positive:
+        assert ball.vx > 0
+    else:
+        assert ball.vx < 0
+
+    if expect_vy_positive:
+        assert ball.vy > 0
+    else:
+        assert ball.vy < 0

--- a/tests/test_ball.py
+++ b/tests/test_ball.py
@@ -1,13 +1,27 @@
+import pytest
 import pygame
 
 from bbreaker.Ball import Ball
-from bbreaker.Brick import Brick
 
+# Arrange
+@pytest.mark.parametrize(
+    "start_pos, end_pos, expect_none",
+    [
+        ((100, 200), (100, 100), True),   # Upward drag - invalid
+        ((100, 100), (-20, 120), True),  # Drag angle too shallow to the left - invalid
+        ((100, 100), (220, 120), True),   # Drag angle too shallow to the right - invalid
+        ((100, 100), (100, 120), False), # Straight down - valid
+        ((100, 100), (-18, 121), False), # Downward left - valid
+        ((100, 100), (218, 121), False),  # Downward right - valid
+    ]
+)
 
-def test_handle_one_brick_collision():
-    surface = pygame.display.set_mode((800, 800))
-    ball = Ball(surface, 10, 10)
-    rect = pygame.Rect(100, 100, 60, 60)
-    brick = Brick(rect, number=1)
+def test_calculate_strike_angle(start_pos, end_pos, expect_none):
+    # Act
+    angle = Ball.calculate_strike_angle(start_pos, end_pos)
 
-    assert True
+    # Assert
+    if expect_none:
+        assert angle is None
+    else:
+        assert angle is not None

--- a/tests/test_ball.py
+++ b/tests/test_ball.py
@@ -25,3 +25,35 @@ def test_calculate_strike_angle(start_pos, end_pos, expect_none):
         assert angle is None
     else:
         assert angle is not None
+
+# Arrange
+@pytest.mark.parametrize(
+    "x, y, vx, vy, expect_vy_positive",
+    [                           
+        (400, 300, -5, -5, False), # No wall contact - vy unchanged 
+        (5, 200, -5, -5, False), # Left wall contact - vy unchanged
+        (400, 4, -5, -5, True), # Top wall contact - vy flips
+    ]
+)
+
+def test_ball_bounces_off_top_wall(x, y, vx, vy, expect_vy_positive):
+    # Arrange
+    pygame.display.set_mode((800, 600))
+    surface = pygame.display.get_surface()
+
+    ball = Ball(surface)
+    ball.x = x
+    ball.y = y
+    ball.vx = vx
+    ball.vy = vy
+
+    ball.game_on = True
+
+    # Act
+    ball.update(surface)
+
+    # Assert
+    if expect_vy_positive:
+        assert ball.vy > 0
+    else:
+        assert ball.vy < 0


### PR DESCRIPTION
This PR adds a comprehensive pytest-based test suite for the Ball module, covering
strike angle validation, wall collisions, and brick collision handling.

While adding tests, a logic bug was identified in three-brick collision handling
(where the one-brick handler was also invoked). This PR fixes that issue by restructuring
the conditional logic to use an if/elif/else pattern.

A detailed explanation of the testing approach and findings is included in CONTRIBUTION.md.